### PR TITLE
Fix bug : RetrievalAugmentorSettings : cannot deserialize from Object…

### DIFF
--- a/backend/src/main/java/ai/dragon/properties/raag/RetrievalAugmentorSettings.java
+++ b/backend/src/main/java/ai/dragon/properties/raag/RetrievalAugmentorSettings.java
@@ -1,10 +1,14 @@
 package ai.dragon.properties.raag;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class RetrievalAugmentorSettings {
     public static final Integer DEFAULT_MAX_MESSAGES = 10;
     public static final Integer DEFAULT_MAX_TOKENS = 3000;


### PR DESCRIPTION
… value

com.fasterxml.jackson.databind.exc.InvalidDefinitionException: Cannot construct instance of `ai.dragon.properties.raag.RetrievalAugmentorSettings` (no Creators, like default constructor, exist): cannot deserialize from Object value (no dele gate- or property-based Creator)

