### PR TITLE
Enhance GitHub Actions Workflow and Add JaCoCo for Code Coverage Reporting

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,9 @@ name: Build dRAGon Project
 on: 
   - push
   - workflow_dispatch
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -1,6 +1,7 @@
 plugins {
 	id 'java'
 	id 'java-library'
+	id 'jacoco'
 	id 'checkstyle' 
 	id 'application'
 	id 'org.springframework.boot' version '3.3.0'
@@ -98,6 +99,18 @@ jar {
             'Implementation-Version': version
         )
     }
+}
+
+test {
+    finalizedBy jacocoTestReport
+}
+
+jacocoTestReport {
+    dependsOn test
+}
+
+jacoco {
+    toolVersion = "0.8.12"
 }
 
 tasks.register("bootProdRun") {

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -102,11 +102,17 @@ jar {
 }
 
 test {
+	useJUnitPlatform()
     finalizedBy jacocoTestReport
 }
 
 jacocoTestReport {
     dependsOn test
+    reports {
+        xml.required = true
+        html.required = true
+        csv.required = true
+    }
 }
 
 jacoco {
@@ -136,8 +142,4 @@ tasks.named('compileJava') {
 
 tasks.named('processResources') {
 	dependsOn('copyWebApp')
-}
-
-tasks.named('test') {
-	useJUnitPlatform()
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced concurrency management for GitHub Actions workflows, allowing multiple instances to run simultaneously without canceling previous ones.
  - Added code coverage reporting capabilities through the integration of the JaCoCo plugin, enhancing the project's testing configuration.

- **Improvements**
  - Enhanced testing setup to automatically generate detailed code coverage reports in multiple formats after test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->