### PR TITLE
chore: Migrate OpenAiCompatibleV1ApiControllerTest to gpt-3.5-turbo model

### DIFF
--- a/backend/src/test/java/ai/dragon/controller/api/raag/OpenAiCompatibleV1ApiControllerTest.java
+++ b/backend/src/test/java/ai/dragon/controller/api/raag/OpenAiCompatibleV1ApiControllerTest.java
@@ -58,7 +58,7 @@ public class OpenAiCompatibleV1ApiControllerTest extends AbstractTest {
 
         // OpenAI settings for RaaG
         String apiKeySetting = String.format("apiKey=%s", System.getenv("OPENAI_API_KEY"));
-        String modelNameSetting = "modelName=gpt-4o";
+        String modelNameSetting = "modelName=gpt-3.5-turbo"; // TODO Migrate to gpt-4o-mini when reliable
 
         // Farm with no silo
         FarmEntity farmWithoutSilo = new FarmEntity();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the API model used in testing from "gpt-4o" to "gpt-3.5-turbo" for improved reliability and stability. 
	- Note on future plans to revert to "gpt-4o-mini" once performance is satisfactory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->